### PR TITLE
Storage container mocking (and a few other mocking fixes)

### DIFF
--- a/lib/fog/rackspace/cdn.rb
+++ b/lib/fog/rackspace/cdn.rb
@@ -190,6 +190,12 @@ module Fog
          })
         end
       end
+
+      class Mock < Fog::Rackspace::Service
+        def enabled?
+          true
+        end
+      end
     end
   end
 end

--- a/lib/fog/rackspace/mock_data.rb
+++ b/lib/fog/rackspace/mock_data.rb
@@ -8,8 +8,8 @@ module Fog
         @@data ||= Hash.new do |hash, key|
           hash[key] = begin
             #Compute V2
-            flavor_id  = Fog.credentials[:rackspace_flavor_id].to_s ||= Fog::Mock.random_numbers(1)
-            image_id   = Fog.credentials[:rackspace_image_id] ||= Fog::Rackspace::MockData.uuid
+            flavor_id  = Fog::Mock.random_numbers(1)
+            image_id   = Fog::Rackspace::MockData.uuid
             image_name = Fog::Mock.random_letters(6)
             network_id = Fog::Rackspace::MockData.uuid
             user_id    =  Fog::Mock.random_numbers(6).to_s
@@ -128,6 +128,9 @@ module Fog
               :snapshots          => {},
               :volume_attachments => [],
               :volume_types       => {volume_type1_id => volume_type1, volume_type2_id => volume_type2},
+
+              #Storage
+              :directories => Hash.new { }
             }
             
             # seed with initial data

--- a/lib/fog/rackspace/requests/load_balancers/create_load_balancer.rb
+++ b/lib/fog/rackspace/requests/load_balancers/create_load_balancer.rb
@@ -30,10 +30,10 @@ module Fog
           data = {"loadBalancer"=>{"name"=>name, "id"=>uniq_id, "protocol"=>protocol, "port"=>port, "algorithm"=>"RANDOM", "status"=>"BUILD",
                                    "cluster"=>{"name"=>"ztm-n13.dfw1.lbaas.rackspace.net"}, "timeout"=>30, "created"=>{"time"=>"2013-08-20T20:52:44Z"},
                                    "updated"=>{"time"=>"2013-08-20T20:52:44Z"}, "halfClosed"=>false, "connectionLogging"=>{"enabled"=>false}, "contentCaching"=>{"enabled"=>false}}}
-          data["virtual_ips"] = virtual_ips.collect {|n| {"virtualIps"=>[{"address"=>"192.237.192.152", "id"=>uniq_id, "type"=>n[:type], "ipVersion"=>"IPV4"}, {"address"=>"2001:4800:7901:0000:ba81:a6a5:0000:0002", "id"=>9153169, "type"=>"PUBLIC", "ipVersion"=>"IPV6"}], "sourceAddresses"=>{"ipv6Public"=>"2001:4800:7901::13/64", "ipv4Servicenet"=>"10.189.254.5", "ipv4Public"=>"166.78.44.5"}}
+          data["virtual_ips"] = virtual_ips.collect {|n| {"virtualIps"=>[{"address"=>"192.237.192.152", "id"=>uniq_id, "type"=>n[:type], "ipVersion"=>"IPV4"}, {"address"=>"2001:4800:7901:0000:ba81:a6a5:0000:0002", "id"=>9153169, "type"=>"PUBLIC", "ipVersion"=>"IPV6"}], "sourceAddresses"=>{"ipv6Public"=>"2001:4800:7901::13/64", "ipv4Servicenet"=>"10.189.254.5", "ipv4Public"=>"166.78.44.5"}}}
           data["nodes"] = nodes.collect {|n| {"address"=>n[:address], "id"=>uniq_id, "type"=>"PRIMARY", "port"=>n[:port], "status"=>"ONLINE", "condition"=>"ENABLED", "weight"=>1}}
-          data = Excon::Response.new(:body => data, :status => 202)
-          }
+
+          Excon::Response.new(:body => data, :status => 202)
         end
       end
     end

--- a/lib/fog/rackspace/requests/storage/delete_container.rb
+++ b/lib/fog/rackspace/requests/storage/delete_container.rb
@@ -20,6 +20,17 @@ module Fog
         end
 
       end
+
+      class Mock
+        def delete_container(name)
+          container_data = self.data[:directories][name]
+          if container_data.nil?
+            raise Fog::Storage::Rackspace::NotFound
+          else
+            response
+          end
+        end
+      end
     end
   end
 end

--- a/lib/fog/rackspace/requests/storage/get_container.rb
+++ b/lib/fog/rackspace/requests/storage/get_container.rb
@@ -43,6 +43,19 @@ module Fog
         end
 
       end
+
+      class Mock
+        def get_container(container, options = {})
+          container_data = self.data[:directories][container]
+          if container_data.nil?
+            raise Fog::Storage::Rackspace::NotFound
+          else
+            # container_response = Fog::Rackspace::MockData.keep(container, 'id', 'name', 'hostId', 'created', 'updated', 'status', 'progress', 'user_id', 'tenant_id', 'links', 'metadata', 'accessIPv4', 'accessIPv6', 'OS-DCF:diskConfig', 'rax-bandwidth:bandwidth', 'addresses', 'flavor', 'image')
+            # container_response['image']['links'].map! { |l| l.delete("type"); l }
+            response(:body => ['a', 'b'])
+          end
+        end
+      end
     end
   end
 end

--- a/lib/fog/rackspace/requests/storage/get_container.rb
+++ b/lib/fog/rackspace/requests/storage/get_container.rb
@@ -50,9 +50,15 @@ module Fog
           if container_data.nil?
             raise Fog::Storage::Rackspace::NotFound
           else
-            # container_response = Fog::Rackspace::MockData.keep(container, 'id', 'name', 'hostId', 'created', 'updated', 'status', 'progress', 'user_id', 'tenant_id', 'links', 'metadata', 'accessIPv4', 'accessIPv6', 'OS-DCF:diskConfig', 'rax-bandwidth:bandwidth', 'addresses', 'flavor', 'image')
-            # container_response['image']['links'].map! { |l| l.delete("type"); l }
-            response(:body => ['a', 'b'])
+            response(:body => [
+              {
+                "hash"=>Fog::Mock.random_hex(32),
+                "last_modified"=>Time.now.utc.iso8601,
+                "bytes"=>Fog::Mock.random_numbers(3),
+                "name"=>"this.rb",
+                "content_type"=>"application/x-ruby"
+              }
+            ])
           end
         end
       end

--- a/lib/fog/rackspace/requests/storage/get_containers.rb
+++ b/lib/fog/rackspace/requests/storage/get_containers.rb
@@ -32,6 +32,12 @@ module Fog
         end
 
       end
+
+      class Mock
+        def get_containers(options = {})
+          response(:body => [{'bytes' => 1, 'count' => 5, 'name' => 'asdf'}])
+        end
+      end
     end
   end
 end

--- a/lib/fog/rackspace/requests/storage/get_object.rb
+++ b/lib/fog/rackspace/requests/storage/get_object.rb
@@ -29,6 +29,16 @@ module Fog
         end
 
       end
+
+      class Mock
+        def get_object(container, object)
+          response({
+              :headers => {
+                'ETag' => '12345'
+              }
+            })
+        end
+      end
     end
   end
 end

--- a/lib/fog/rackspace/requests/storage/head_container.rb
+++ b/lib/fog/rackspace/requests/storage/head_container.rb
@@ -27,6 +27,17 @@ module Fog
         end
 
       end
+
+      class Mock
+        def head_container(container)
+          container_data = self.data[:directories][container]
+          if container_data.nil?
+            raise Fog::Storage::Rackspace::NotFound
+          else
+            response(:headers => container_data[:headers])
+          end
+        end
+      end
     end
   end
 end

--- a/lib/fog/rackspace/requests/storage/head_containers.rb
+++ b/lib/fog/rackspace/requests/storage/head_containers.rb
@@ -24,6 +24,12 @@ module Fog
         end
 
       end
+
+      class Mock
+        def head_containers
+          response(:body => '')
+        end
+      end
     end
   end
 end

--- a/lib/fog/rackspace/requests/storage/head_object.rb
+++ b/lib/fog/rackspace/requests/storage/head_object.rb
@@ -21,6 +21,14 @@ module Fog
         end
 
       end
+
+      class Mock
+        def head_object(container, object)
+          response = get_object(container, object)
+          response.body = nil
+          response
+        end
+      end
     end
   end
 end

--- a/lib/fog/rackspace/requests/storage/put_container.rb
+++ b/lib/fog/rackspace/requests/storage/put_container.rb
@@ -21,6 +21,13 @@ module Fog
         end
 
       end
+
+      class Mock
+        def put_container(name, options={})
+          self.data[:directories][name] = {:headers => options}
+          response(:body => response)
+        end
+      end
     end
   end
 end

--- a/lib/fog/rackspace/requests/storage/put_object.rb
+++ b/lib/fog/rackspace/requests/storage/put_object.rb
@@ -31,6 +31,12 @@ module Fog
           request(params)
         end
       end
+
+      class Mock
+        def put_object(container, object, data, options = {}, &block)
+          response
+        end
+      end
     end
   end
 end

--- a/lib/fog/rackspace/storage.rb
+++ b/lib/fog/rackspace/storage.rb
@@ -62,16 +62,29 @@ module Fog
 
       class Mock < Fog::Rackspace::Service
         include Utils
+        include Fog::Rackspace::MockData
 
-        def self.data
-          @data ||= Hash.new do |hash, key|
-            hash[key] = {}
+        def response(params={})
+          body    = params[:body] || {}
+          status  = params[:status] || 200
+          headers = params[:headers] || {}
+
+          response = Excon::Response.new(:body => body, :headers => headers, :status => status)
+          if params.has_key?(:expects) && ![*params[:expects]].include?(response.status)
+            raise(Excon::Errors.status_error(params, response))
+          else response
           end
         end
 
-        def self.reset
-          @data = nil
-        end
+        # def self.data
+        #   @data ||= Hash.new do |hash, key|
+        #     hash[key] = {}
+        #   end
+        # end
+
+        # def self.reset
+        #   @data = nil
+        # end
 
         def initialize(options={})
           require 'mime/types'
@@ -80,13 +93,13 @@ module Fog
           @rackspace_cdn_ssl = options[:rackspace_cdn_ssl]
         end
 
-        def data
-          self.class.data[@rackspace_username]
-        end
+        # def data
+        #   self.class.data[@rackspace_username]
+        # end
 
-        def reset_data
-          self.class.data.delete(@rackspace_username)
-        end
+        # def reset_data
+        #   self.class.data.delete(@rackspace_username)
+        # end
 
         def service_name
           :cloudFiles

--- a/tests/rackspace/helper.rb
+++ b/tests/rackspace/helper.rb
@@ -59,6 +59,7 @@ module Shindo
 
     def rackspace_test_image_id(service) 
       # I chose to use the first Ubuntu because it will work with the smallest flavor and it doesn't require a license
+      @image_id = service.images.first if Fog.mocking? # Should find Ubuntu, but v2 Mock is not initialized with a realistic image list right now.
       @image_id ||= Fog.credentials[:rackspace_image_id] || service.images.find {|img| img.name =~ /Ubuntu/ }.id
     end
 

--- a/tests/rackspace/requests/storage/container_tests.rb
+++ b/tests/rackspace/requests/storage/container_tests.rb
@@ -1,6 +1,12 @@
 Shindo.tests('Fog::Storage[:rackspace] | container requests', ["rackspace"]) do
 
-  @container_format = [String]
+  @container_format = [{
+    'hash' => String,
+    'last_modified'=>String,
+    'bytes' => String,
+    'name'  => String,
+    'content_type'=>String
+    }]
 
   @containers_format = [{
     'bytes' => Integer,

--- a/tests/rackspace/requests/storage/container_tests.rb
+++ b/tests/rackspace/requests/storage/container_tests.rb
@@ -11,39 +11,32 @@ Shindo.tests('Fog::Storage[:rackspace] | container requests', ["rackspace"]) do
   tests('success') do
 
     tests("#put_container('fogcontainertests', {})").succeeds do
-      pending if Fog.mocking?
       Fog::Storage[:rackspace].put_container('fogcontainertests')
     end
 
     tests("#put_container('fogcontainertests', 'X-Container-Meta-Color'=>'green')").succeeds do
-      pending if Fog.mocking?
       Fog::Storage[:rackspace].put_container('fogcontainertests', 'X-Container-Meta-Color'=>'green')
       response = Fog::Storage[:rackspace].head_container('fogcontainertests')
       returns('green') { response.headers['X-Container-Meta-Color'] }
     end
 
     tests("#get_container('fogcontainertests')").formats(@container_format) do
-      pending if Fog.mocking?
       Fog::Storage[:rackspace].get_container('fogcontainertests').body
     end
 
     tests("#get_containers").formats(@containers_format) do
-      pending if Fog.mocking?
       Fog::Storage[:rackspace].get_containers.body
     end
 
     tests("#head_container('fogcontainertests')").succeeds do
-      pending if Fog.mocking?
       Fog::Storage[:rackspace].head_container('fogcontainertests')
     end
 
     tests("#head_containers").succeeds do
-      pending if Fog.mocking?
       Fog::Storage[:rackspace].head_containers
     end
 
     tests("#delete_container('fogcontainertests')").succeeds do
-      pending if Fog.mocking?
       Fog::Storage[:rackspace].delete_container('fogcontainertests')
     end
 
@@ -52,17 +45,14 @@ Shindo.tests('Fog::Storage[:rackspace] | container requests', ["rackspace"]) do
   tests('failure') do
 
     tests("#get_container('fognoncontainer')").raises(Fog::Storage::Rackspace::NotFound) do
-      pending if Fog.mocking?
       Fog::Storage[:rackspace].get_container('fognoncontainer')
     end
 
     tests("#head_container('fognoncontainer')").raises(Fog::Storage::Rackspace::NotFound) do
-      pending if Fog.mocking?
       Fog::Storage[:rackspace].head_container('fognoncontainer')
     end
 
     tests("#delete_container('fognoncontainer')").raises(Fog::Storage::Rackspace::NotFound) do
-      pending if Fog.mocking?
       Fog::Storage[:rackspace].delete_container('fognoncontainer')
     end
 


### PR DESCRIPTION
Sending PR to rackspace first for review.

This PR implements storage mocking.  It also contains some minor fixes to load balancer mocking and compute mocking that were in my way.

I removed `pending if Fog.mocking?` from all the container tests and made them pass.  I haven't added all the other storage services, but container seems to cover the majority of actions.  I've also been testing it with some real-world applications, because the tests alone aren't enough to make sure it is a _good_ implementation of mocking.
